### PR TITLE
Updated to use the latest Engage packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# System
+.DS_Store
+
+# IDE
+.git/
+.vscode/
+.idea/
+
 # Logs
 logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .DS_Store
 
 # IDE
-.git/
 .vscode/
 .idea/
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@awesome-organization/awesome-extension",
+  "name": "@awesomeOrganization/awesomeExtension",
   "version": "1.0.0",
   "description": "",
   "license": "Apache-2.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@awesomeOrganization/awesomeExtension",
+  "name": "@awesome-organization/awesome-extension",
   "version": "1.0.0",
   "description": "",
   "license": "Apache-2.0",
@@ -7,6 +7,6 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "standard": "^10.0.3"
+    "standard": "^17.1.2"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@awesome-organization/awesome-extension",
+  "name": "@awesomeOrganization/awesomeExtension",
   "version": "1.0.0",
   "description": "",
   "license": "Apache-2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,9 @@
     "jest": "^29.7.0",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-redux": "^8.1.3",
+    "reselect": "^4.1.8"
   },
   "peerDependencies": {
     "@shopgate/engage": "^7.30.4"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@awesomeOrganization/awesomeExtension",
+  "name": "@awesome-organization/awesome-extension",
   "version": "1.0.0",
-  "description": "An awesome extesion for my awesome organization",
+  "description": "",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",
@@ -10,19 +10,22 @@
     "coverage:watch": "npm run coverage -- --watch"
   },
   "devDependencies": {
-    "@shopgate/engage": "^6.7.1",
-    "@shopgate/eslint-config": "^6.7.1",
-    "@shopgate/pwa-common": "^6.7.1",
-    "@shopgate/pwa-common-commerce": "^6.7.1",
-    "@shopgate/pwa-core": "^6.7.1",
-    "@shopgate/pwa-unit-test": "^6.7.1",
-    "eslint": "~5.12.0",
-    "jest": "^24.8.0",
-    "prop-types": "^15.6.0",
-    "react": "~16.8.4",
-    "react-dom": "~16.8.4"
+    "@types/react": "^17.0.2",
+    "@shopgate/engage": "^7.30.4",
+    "@shopgate/eslint-config": "^7.30.4",
+    "@shopgate/pwa-unit-test": "^7.30.4",
+    "eslint": "^8.57.1",
+    "jest": "^29.7.0",
+    "prop-types": "^15.8.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "@shopgate/pwa-common": "^6.7.1"
+    "@shopgate/engage": "^7.30.4"
+  },
+  "overrides": {
+    "enzyme": {
+      "cheerio": "1.0.0-rc.3"
+    }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,9 +22,6 @@
     "react-redux": "^8.1.3",
     "reselect": "^4.1.8"
   },
-  "peerDependencies": {
-    "@shopgate/engage": "^7.30.4"
-  },
   "overrides": {
     "enzyme": {
       "cheerio": "1.0.0-rc.3"


### PR DESCRIPTION
This pull request updates dev dependencies to the latest versions. Also added `react-redux` and `reselect` packages to the frontend package.json.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates dev dependencies across both the `extension` and `frontend` packages to their latest versions, aligning them with the Shopgate Engage 7.x release line. It also adds `react-redux` and `reselect` to the frontend boilerplate and consolidates previously explicit `pwa-common`/`pwa-common-commerce`/`pwa-core` entries (now expected to be pulled in transitively via `@shopgate/engage`).

- **`frontend/package.json`**: All `@shopgate/*` packages bumped from `^6.7.1` to `^7.30.4`; `react`/`react-dom` moved to `^17.0.2`; `eslint` jumped from `~5.12.0` to `^8.57.1`; `jest` from `^24.8.0` to `^29.7.0`; `react-redux@^8.1.3` and `reselect@^4.1.8` added; `peerDependencies` replaced with a `cheerio` override for enzyme compatibility.
- **`extension/package.json`**: `standard` bumped from `^10.0.3` to `^17.1.2` (seven major versions).
- **`.gitignore`**: Added `.DS_Store`, `.vscode/`, and `.idea/` exclusions.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge for boilerplate purposes, but worth verifying whether react-redux and reselect are expected to be bundled or installed as runtime packages before distributing.

The dependency classification of react-redux and reselect under devDependencies is a potential gap: if extension builds ever run with production-only installs, these packages would be absent at runtime. All other changes are straightforward version bumps with no logic alterations.

frontend/package.json — specifically the devDependencies vs dependencies placement of react-redux and reselect, and the extension/package.json standard version jump.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .gitignore | Added .DS_Store, .vscode/, and .idea/ ignore entries — standard OS/IDE exclusions, no issues. |
| extension/package.json | Bumps standard linter from ^10.0.3 to ^17.1.2 — a 7-major-version jump that may introduce new lint failures in existing extension code. |
| frontend/package.json | Upgrades all Shopgate packages from 6.x to 7.x, adds react-redux and reselect, removes pwa-common/pwa-common-commerce/pwa-core, and replaces peerDependencies with a cheerio override for enzyme compatibility. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph frontend["frontend/package.json (devDependencies)"]
        engage["@shopgate/engage ^7.30.4 (was ^6.7.1)"]
        react["react ^17.0.2 (was ~16.8.4)"]
        jest["jest ^29.7.0 (was ^24.8.0)"]
        reactredux["react-redux ^8.1.3 NEW"]
        reselect["reselect ^4.1.8 NEW"]
    end
    subgraph removed["Removed from frontend"]
        pwac["@shopgate/pwa-common ^6.7.1"]
        pwacc["@shopgate/pwa-common-commerce ^6.7.1"]
        pwacore["@shopgate/pwa-core ^6.7.1"]
    end
    subgraph extension["extension/package.json"]
        standard["standard ^17.1.2 (was ^10.0.3)"]
    end
    engage --> |"likely bundles"| pwac
    engage --> |"likely bundles"| pwacc
    engage --> |"likely bundles"| pwacore
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
extension/package.json:10
**Seven-major-version jump in `standard`**

`standard` is jumping from `^10.0.3` to `^17.1.2`, crossing seven major versions. Each major release tightened or changed lint rules (e.g. v11 dropped Node 4/6 support, v14+ enforced ES2019+ globals, v16+ enabled stricter spacing/padding rules). Any existing extension code that passes v10 cleanly may start failing under v17 with no change to the source. It's worth running `npx standard` after installing to confirm there are no new violations before distributing this boilerplate.

### Issue 2 of 2
frontend/package.json:22-23
**`react-redux` and `reselect` placed in `devDependencies`**

Both `react-redux` and `reselect` are runtime dependencies intended for use in production extension code (not just tests). Listing them under `devDependencies` means they are excluded when the package is installed with `npm install --production` or `npm ci --omit=dev`. If extension developers follow that deployment pattern, the extension will fail at runtime with a missing-module error. They should be moved to `dependencies`.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["CURB-5679 Removed peer dependencies"](https://github.com/shopgate/cloud-sdk-boilerplate-extension/commit/c4e3defdbbb4fe90ddc87e73ecdfc11fd9da4109) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33901298)</sub>

<!-- /greptile_comment -->